### PR TITLE
allow using es6 feature in node env (e.g. Promise)

### DIFF
--- a/eslint/node.yml
+++ b/eslint/node.yml
@@ -6,3 +6,4 @@ parserOptions:
   sourceType: 'module'
 env:
   node: true
+  es6: true


### PR DESCRIPTION
This should only affect laboperator drivers and middlewares..